### PR TITLE
spring-hw-11

### DIFF
--- a/core-service/pom.xml
+++ b/core-service/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
-            <version>3.2.1</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -109,7 +108,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.2</version>
         </dependency>
     </dependencies>
 

--- a/front-service/pom.xml
+++ b/front-service/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.1</version>
+		<version>3.3.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>ru.gb</groupId>
@@ -22,7 +22,8 @@
 		<module>front-service</module>
 		<module>discovery-service</module>
 		<module>api</module>
-    </modules>
+		<module>starter-aspect</module>
+	</modules>
 
 	<properties>
 		<java.version>17</java.version>

--- a/reader-service/pom.xml
+++ b/reader-service/pom.xml
@@ -97,7 +97,12 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>ru.gb</groupId>
+            <artifactId>starter-aspect</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/reader-service/src/main/resources/application.yml
+++ b/reader-service/src/main/resources/application.yml
@@ -27,3 +27,8 @@ eureka:
   client:
     service-url:
       defaultZone: http://localhost:8761/eureka
+
+starter-aspect:
+  properties:
+    enabled: true
+    log-level: info

--- a/starter-aspect/pom.xml
+++ b/starter-aspect/pom.xml
@@ -7,10 +7,10 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>discovery-service</artifactId>
+    <artifactId>starter-aspect</artifactId>
     <packaging>jar</packaging>
 
-    <name>discovery-service</name>
+    <name>starter-aspect</name>
     <url>http://maven.apache.org</url>
 
     <properties>
@@ -19,9 +19,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
-            <version>4.1.2</version>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/starter-aspect/src/main/java/ru/gb/aspect/AnnotationsHandler.java
+++ b/starter-aspect/src/main/java/ru/gb/aspect/AnnotationsHandler.java
@@ -1,0 +1,94 @@
+package ru.gb.aspect;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.event.Level;
+import ru.gb.aspect.annotations.RecoverException;
+
+@Slf4j
+@Aspect
+@RequiredArgsConstructor
+public class AnnotationsHandler {
+
+    private final LoggingProperties loggingProperties;
+
+//    @Pointcut("@within(ru.gb.aspect.annotations.Timer)")
+//    public void classAnnotatedTimer() {}
+//
+//    @Pointcut("@annotation(ru.gb.aspect.annotations.Timer)")
+//    public void methodAnnotatedTimer() {}
+
+    //@Around("classAnnotatedTimer() || methodAnnotatedTimer()")
+    @Around("@annotation(ru.gb.aspect.annotations.Timer) || @within(ru.gb.aspect.annotations.Timer)")
+    public Object timerHandler(ProceedingJoinPoint joinPoint) throws Throwable {
+        Level level = loggingProperties.getLogLevel();
+        Object result = null;
+        long start = System.currentTimeMillis();
+        try {
+            result = joinPoint.proceed();
+        } catch (Throwable e) {
+            log.error("exception: {}, {}", e.getClass(), e.getMessage());
+            throw e;
+        }
+        long deltaTime = System.currentTimeMillis() - start;
+        log.atLevel(level).log("=====   Timer   =====");
+        log.atLevel(level).log("{} - {} #({}ms)", joinPoint.getTarget().getClass().getSimpleName(),
+                joinPoint.getSignature().getName(), deltaTime);
+        return result;
+    }
+
+//    @Pointcut("@annotation(ru.gb.aspect.annotations.RecoverException)")
+//    public void methodAnnotatedRecoverException() {}
+
+    //@Around("methodAnnotatedRecoverException()")
+    @Around("@annotation(ru.gb.aspect.annotations.RecoverException)")
+    public Object recoverExceptionHandler(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object result = null;
+        Class<? extends RuntimeException>[] exceptions = extractExceptions(joinPoint);
+        String returnTypeName = ((MethodSignature)joinPoint.getSignature())
+                .getReturnType().getSimpleName();
+        try {
+            result = joinPoint.proceed();
+        } catch (Throwable e) {
+            if (isExceptionContains(exceptions, e)) {
+                throw e;
+            } else {
+                if (Character.isUpperCase(returnTypeName.charAt(0))) {
+                    return null;
+                }
+                switch (returnTypeName) {
+                    case "boolean": return false;
+                    case "char": return ' ';
+                    case "void": return null;
+                    default: return 0;
+                }
+            }
+        }
+        return result;
+    }
+
+    private Class<? extends RuntimeException>[] extractExceptions(ProceedingJoinPoint joinPoint) {
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        RecoverException annotation = methodSignature.getMethod()
+                .getAnnotation(RecoverException.class);
+        if (annotation != null) {
+            return annotation.noRecoverFor();
+        }
+        return null;
+    }
+
+    private boolean isExceptionContains(Class<? extends RuntimeException>[] exceptions, Throwable e) {
+        if (exceptions != null) {
+            for (Class<? extends RuntimeException> exception : exceptions) {
+                if (exception.equals(e.getClass())) return true;
+                if (exception.isAssignableFrom(e.getClass())) return true;
+            }
+        }
+        return false;
+    }
+}

--- a/starter-aspect/src/main/java/ru/gb/aspect/LoggingProperties.java
+++ b/starter-aspect/src/main/java/ru/gb/aspect/LoggingProperties.java
@@ -1,0 +1,15 @@
+package ru.gb.aspect;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.slf4j.event.Level;
+
+@Data
+@ConfigurationProperties("starter-aspect.properties")
+public class LoggingProperties {
+
+    /**
+     * Настроить уровень логирования.
+     */
+    private Level logLevel = Level.DEBUG;
+}

--- a/starter-aspect/src/main/java/ru/gb/aspect/StarterAspectAutoConfiguration.java
+++ b/starter-aspect/src/main/java/ru/gb/aspect/StarterAspectAutoConfiguration.java
@@ -1,0 +1,17 @@
+package ru.gb.aspect;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(LoggingProperties.class)
+@ConditionalOnProperty(value = "starter-aspect.properties.enabled", havingValue = "true")
+public class StarterAspectAutoConfiguration {
+
+    @Bean
+    public AnnotationsHandler annotationsHandler(LoggingProperties loggingProperties) {
+        return new AnnotationsHandler(loggingProperties);
+    }
+}

--- a/starter-aspect/src/main/java/ru/gb/aspect/annotations/RecoverException.java
+++ b/starter-aspect/src/main/java/ru/gb/aspect/annotations/RecoverException.java
@@ -1,0 +1,12 @@
+package ru.gb.aspect.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RecoverException {
+    Class<? extends RuntimeException>[] noRecoverFor() default {};
+}

--- a/starter-aspect/src/main/java/ru/gb/aspect/annotations/Timer.java
+++ b/starter-aspect/src/main/java/ru/gb/aspect/annotations/Timer.java
@@ -1,0 +1,11 @@
+package ru.gb.aspect.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Timer {
+}

--- a/starter-aspect/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/starter-aspect/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+ru.gb.aspect.StarterAspectAutoConfiguration


### PR DESCRIPTION
Комментарии:
1. Стартер сделал, всё работает.
2. Все аннотации, которые вставлял в коде для проверки работоспособности, поубирал, чтобы в пулл-реквесте было поменьше мусора, и проверять было проще. Зависимость оставил только в reader-service.
3. Долго не мог заставить аспект работать. Экспериментальным методом выяснил, что аннотация @Pointcut не работает. Возможно, какой-то баг версии спринг-бута 3.3.0. К счастью, в данном случае без неё вполне можно обойтись.
4. Добавил возможность включать-выключать аспект через @ConditionalOnProperty, а также уровни логирования.