### PR TITLE
spring-hw-12

### DIFF
--- a/core-service/pom.xml
+++ b/core-service/pom.xml
@@ -115,6 +115,12 @@
             <artifactId>starter-aspect</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core-service/src/main/java/ru/gb/library/core/configurations/JwtTokenUtil.java
+++ b/core-service/src/main/java/ru/gb/library/core/configurations/JwtTokenUtil.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.function.Function;
 
 @Component
+@ConditionalOnMissingClass
 @RequiredArgsConstructor
 public class JwtTokenUtil {
     @Value("${jwt.secret}")

--- a/core-service/src/main/java/ru/gb/library/core/configurations/SecurityConfig.java
+++ b/core-service/src/main/java/ru/gb/library/core/configurations/SecurityConfig.java
@@ -2,6 +2,7 @@ package ru.gb.library.core.configurations;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -21,6 +22,7 @@ public class SecurityConfig {
     private final JwtRequestFilter jwtRequestFilter;
 
     @Bean
+    @ConditionalOnMissingBean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         log.info("===============================================================");
         log.info("Dao Authentication Provider");

--- a/core-service/src/main/java/ru/gb/library/core/integrations/ReaderServiceIntegration.java
+++ b/core-service/src/main/java/ru/gb/library/core/integrations/ReaderServiceIntegration.java
@@ -4,6 +4,7 @@ import com.netflix.appinfo.InstanceInfo;
 import com.netflix.discovery.EurekaClient;
 import com.netflix.discovery.shared.Application;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import ru.gb.library.api.ReaderDto;
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Component
+@ConditionalOnMissingClass
 @RequiredArgsConstructor
 public class ReaderServiceIntegration {
     private final WebClient readerServiceWebClient;

--- a/core-service/src/test/java/ru/gb/library/core/IssueControllerTest.java
+++ b/core-service/src/test/java/ru/gb/library/core/IssueControllerTest.java
@@ -4,18 +4,22 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@Import(TestSecurityConfig.class)
 @ActiveProfiles("test")
 @AutoConfigureMockMvc
 public class IssueControllerTest {
@@ -49,14 +53,12 @@ public class IssueControllerTest {
 
 //    @PatchMapping("/{issueId}")
 //    public IssueDto closeIssue(@PathVariable Long issueId)
-//    @Test
-//    public void closeIssueTest() throws Exception {
-//        mockMvc.perform(patch("/issues/3")
-//                        .with(SecurityMockMvcRequestPostProcessors.jwt()
-//                                .authorities(new SimpleGrantedAuthority("ROLE_ADMIN")))
-//                        .contentType(MediaType.APPLICATION_JSON))
-//                .andDo(print())
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.dateOfReturn", notNullValue()));
-//    }
+    @Test
+    public void closeIssueTest() throws Exception {
+        mockMvc.perform(patch("/issues/3")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dateOfReturn", notNullValue()));
+    }
 }

--- a/core-service/src/test/java/ru/gb/library/core/IssueControllerTestTwo.java
+++ b/core-service/src/test/java/ru/gb/library/core/IssueControllerTestTwo.java
@@ -1,0 +1,44 @@
+package ru.gb.library.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import ru.gb.library.api.IssueRequest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Import(TestSecurityConfigTwo.class)
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class IssueControllerTestTwo {
+    @Autowired
+    private MockMvc mockMvc;
+
+//    @PostMapping
+//    public IssueDto openIssue(@RequestBody IssueRequest issueRequest,
+//                              @RequestHeader("Authorization") String token)
+    @Test
+    public void openIssueTest() throws Exception {
+        mockMvc.perform(post("/issues")
+                        .content(new ObjectMapper().writeValueAsString(
+                                new IssueRequest(1L, 1L)))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(16)))
+                .andExpect(jsonPath("$.readerName", is("defaultUser")));
+    }
+}

--- a/core-service/src/test/java/ru/gb/library/core/TestSecurityConfig.java
+++ b/core-service/src/test/java/ru/gb/library/core/TestSecurityConfig.java
@@ -1,7 +1,22 @@
 package ru.gb.library.core;
 
-//@TestConfiguration
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
 public class TestSecurityConfig {
 
-
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorise -> authorise
+                        .anyRequest().permitAll());
+        return http.build();
+    }
 }

--- a/core-service/src/test/java/ru/gb/library/core/TestSecurityConfigTwo.java
+++ b/core-service/src/test/java/ru/gb/library/core/TestSecurityConfigTwo.java
@@ -1,0 +1,35 @@
+package ru.gb.library.core;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import ru.gb.library.api.ReaderDto;
+import ru.gb.library.core.configurations.JwtTokenUtil;
+import ru.gb.library.core.integrations.ReaderServiceIntegration;
+
+import java.util.List;
+
+@TestConfiguration
+public class TestSecurityConfigTwo {
+
+    @Bean
+    public JwtTokenUtil jwtTokenUtil() {
+        return new JwtTokenUtil() {
+            public String getUsernameFromToken(String token) {
+                return "defaultUser";
+            }
+
+            public List<String> getRolesFromToken(String token) {
+                return List.of("ROLE_ADMIN");
+            }
+        };
+    }
+
+    @Bean
+    public ReaderServiceIntegration readerServiceIntegration() {
+        return new ReaderServiceIntegration(null, null) {
+            public ReaderDto getReaderById(Long id, String token) {
+                return new ReaderDto(id, "defaultUser");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Комментарии:
* Хоть в семинаре было сказано, что задание зачитывается автоматом, решил доделать тесты, на которые в 10-м ДЗ меня не хватило.
* Нашёл несколько подходов, с помощью которых можно обойти запрос JWT токена:
1. Ввести бин, который сгенерирует токен с нужными параметрами, которым можно будет пользоваться. В принципе, подход рабочий, но мне не понравилось то, что этому бину нужно дать доступ к secret-key. Не хотелось бы им лишний раз светить. Этот подход реализовывать не стал, хоть он и не сложный.
2. Нашёл одно упоминание, что можно влезть в Security Context, и подправить там Authorities на нужные значения. Данный подход не был описан подробно, поэтому реализовать его мне не удалось.
3. Замена в SecurityConfig бина filterChain на свой, в котором нет ограничений. Этот метод мне я реализовал, см. IssueControllerTest (closeIssueTest()) под управлением TestSecurityConfig. Недостаток этого метода в том, что нужно лезть в основной код и вставлять над основным бином аннотацию @ConditionalOnMissingBean. Насколько это критично, я не знаю. Возможно есть способ подменить бин, не влезая в основной код, но у меня по-другому не заработало.
4. Очень похоже на предыдущий метод, но подменяется не фильтр безопасности, а бин, декодирующий JWT токен. Этот подход я также реализовал, см. IssueControllerTestTwo (openIssueTest()) под управлением TestSecurityConfigTwo. Недостаток тот же, что и в предыдущем пункте. Кроме того, для проверки открытия заказа пришлось подменять ещё и бин интеграции с ридер-сервисом.